### PR TITLE
Fix insert values and limit offset example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ select
     { fielname: 'value' }
   ])
   .order('bar')                 // ORDER BY
-  .limit(10)                    // LIMIT
-  .offset(40)                   // OFFSET
+  .limit(10, 40)                // LIMIT AND OFFSET AS SECOND PARAMETER
   .forUpdate()                  // FOR UPDATE
 ?>
 ```

--- a/README.md
+++ b/README.md
@@ -335,12 +335,11 @@ var insert = dialect.statement('insert');
 
 insert.into('table')               // INTO
       .values([                    // (field1, ...) VALUES (value1, ...)"
-        { field1: 'value1' },
-        { field2: 'value2' }
-      ]);
+        { field1: 'value1', field2: 'value2', anotherField: 'value3' }
+      );
 ```
 
-The `values()` method allows you to pass an array of key-value pairs where the key is the field name and value the field value.
+The `values()` method allows you to pass an object of key-value pairs where the key is the field name and value the field value.
 
 ### UPDATE
 


### PR DESCRIPTION
I just tried to insert an item into the database but it did not work, because the insert example was wrong, so I went to look at the tests and saw that the api was slightly different instead of an array with keys and values, the api correct is that with an object with keys and values

https://github.com/crysalead-js/sql-dialect/blob/93aa1ffc80a803ac9f43ac1856aef89b470285c3/spec/suite/statement/insert.spec.js#L14-L17

https://github.com/crysalead-js/sql-dialect/blob/93aa1ffc80a803ac9f43ac1856aef89b470285c3/spec/suite/statement/postgresql/insert.spec.js#L16

https://github.com/crysalead-js/sql-dialect/blob/93aa1ffc80a803ac9f43ac1856aef89b470285c3/spec/suite/statement/mysql/insert.spec.js#L16-L17