### PR TITLE
statement: initial support for common table expressions

### DIFF
--- a/src/statement/delete.js
+++ b/src/statement/delete.js
@@ -11,7 +11,6 @@ const DELETE = 'DELETE';
  */
 class Delete extends Statement {
 
-
   /**
    * Constructor.
    *
@@ -37,6 +36,7 @@ class Delete extends Statement {
       flags    : new Map(),
       from     : '',
       where    : [],
+      with     : new Map(),
       order    : new Map(),
       limit    : '',
       returning: []
@@ -65,16 +65,18 @@ class Delete extends Statement {
     }
 
     const dialect = this.dialect();
-    return (DELETE +
-      this._buildFlags(this._parts.flags) +
-      this._buildClause(FROM, dialect.names(this._parts.from)) +
+    return [
+      this._buildCTE(),
+      DELETE,
+      this._buildFlags(this._parts.flags),
+      this._buildClause(FROM, dialect.names(this._parts.from)),
       this._buildClause(WHERE,  dialect.conditions(this._parts.where, {
         schemas: { '': this._schema }
-      })) +
-      this._buildOrder() +
-      this._buildClause(LIMIT, this._parts.limit) +
+      })),
+      this._buildOrder(),
+      this._buildClause(LIMIT, this._parts.limit),
       this._buildClause(RETURNING, dialect.names(this._parts.returning))
-     );
+    ].join('');
   }
 
 }

--- a/src/statement/insert.js
+++ b/src/statement/insert.js
@@ -30,6 +30,7 @@ class Insert extends Statement {
       flags     : new Map(),
       into      : '',
       values    : [],
+      with      : new Map(),
       returning : []
     }
   }
@@ -71,6 +72,7 @@ class Insert extends Statement {
     const dialect = this.dialect();
 
     return [
+      this._buildCTE(),
       'INSERT',
       this._buildFlags(this._parts.flags),
       this._buildClause('INTO', dialect.name(this._parts.into, true)),

--- a/src/statement/select.js
+++ b/src/statement/select.js
@@ -30,6 +30,7 @@ class Select extends Statement {
       from     : [],
       joins    : [],
       where    : [],
+      with     : new Map(),
       group    : new Map(),
       having   : [],
       order    : new Map(),
@@ -191,7 +192,8 @@ class Select extends Statement {
     const dialect = this.dialect()
     const fields = dialect.names(this._parts.fields);
     const opts = { schemas: schemas, aliases: aliases }
-    var sql = 'SELECT' +
+    var sql = this._buildCTE() +
+      'SELECT' +
       this._buildFlags(this._parts.flags) +
       this._buildChunk(fields ? fields : '*') +
       this._buildClause('FROM', dialect.names(this._parts.from)) +

--- a/src/statement/update.js
+++ b/src/statement/update.js
@@ -31,6 +31,7 @@ class Update extends Statement {
       table    : '',
       values   : {},
       where    : [],
+      with     : new Map(),
       order    : new Map(),
       limit    : '',
       forUpdate: false,
@@ -74,16 +75,19 @@ class Update extends Statement {
       throw new Error("Invalid `UPDATE` statement, missing `VALUES` clause.");
     }
 
-    return 'UPDATE' +
-      this._buildFlags(this._parts.flags) +
-      this._buildChunk(this.dialect().names(this._parts.table)) +
-      this._buildSet() +
+    return [
+      this._buildCTE(),
+      'UPDATE',
+      this._buildFlags(this._parts.flags),
+      this._buildChunk(this.dialect().names(this._parts.table)),
+      this._buildSet(),
       this._buildClause('WHERE',  this.dialect().conditions(this._parts.where, { schemas: {
         '': this._schema
-      }})) +
-      this._buildOrder() +
-      this._buildClause('LIMIT', this._parts.limit) +
-      this._buildClause('RETURNING', this.dialect().names(this._parts.returning));
+      }})),
+      this._buildOrder(),
+      this._buildClause('LIMIT', this._parts.limit),
+      this._buildClause('RETURNING', this.dialect().names(this._parts.returning))
+    ].join('');
   }
 
   /**


### PR DESCRIPTION
All support dialects have common table expressions at this point.
This includes a first pass at including support for WITH statement on
all DML statements

TODO:

- [ ] RECURSIVE support
- [ ]  add tests

Semver: minor