### PR TITLE
[breaking] dialect: re-map (not) exists operators to subquery builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ Example:
 ```js
 var dialect = new SQL.PostgreSql({
   builders: {
-    braces: function ($operator, $parts) {
-      return "{" . array_shift($parts)  ."}";
+    braces: function (operator, parts) {
+      return `{${parts.join(',')}}`;
     }
   },
   operators: {
@@ -317,7 +317,7 @@ Example of `JOIN` on a subquery:
 var subquery = dialect.statement('select')
 subquery.from('table2').alias('t2');
 
-select.from('table').join($subquery);
+select.from('table').join(subquery);
 
 select.toString();
 // SELECT * FROM "table" LEFT JOIN (SELECT * FROM "table2") AS "t2"

--- a/spec/suite/dialect.spec.js
+++ b/spec/suite/dialect.spec.js
@@ -454,6 +454,17 @@ describe("Dialect", function() {
 
     });
 
+    it("generates a subquery EXISTS expression", function() {
+      var subquery = this.dialect.statement('select');
+      subquery.fields('s1').from('t1');
+      var part = this.dialect.conditions({
+        ':exists': subquery
+      })
+
+      expect(part).toBe('EXISTS (SELECT "s1" FROM "t1")')
+    })
+
+
     it("generates a subquery ANY expression with a subquery instance", function() {
 
       var subquery = this.dialect.statement('select');

--- a/src/dialect.js
+++ b/src/dialect.js
@@ -167,8 +167,8 @@ class Dialect {
       ':not between' : { builder: 'between' },
       ':in'          : { builder: 'list' },
       ':not in'      : { builder: 'list' },
-      ':exists'      : { builder: 'list' },
-      ':not exists'  : { builder: 'list' },
+      ':exists'      : { builder: 'subquery' },
+      ':not exists'  : { builder: 'subquery' },
       ':all'         : { builder: 'list' },
       ':any'         : { builder: 'list' },
       ':some'        : { builder: 'list' },
@@ -207,6 +207,9 @@ class Dialect {
       },
       'alias': function (operator, parts) {
         return '(' + parts.shift() + ') ' + operator + ' ' + parts.shift();
+      },
+      'subquery': function(operator, parts) {
+        return `${operator} (${String(parts[0])})`
       }
     };
   }


### PR DESCRIPTION
The `list` builder was generating incorrect sql for the exits and not
exists operators. This adds a sub query build for these two cases to
render the sql accurately.

These two operators now use the `subquery` builder rather than the
`list` operator

Semver: major
Ref: #11